### PR TITLE
fix(theme): merge highlight overrides safely

### DIFF
--- a/lua/layers/ui/integrations/syntax.lua
+++ b/lua/layers/ui/integrations/syntax.lua
@@ -1,8 +1,10 @@
 local theme = require('base46').get_theme_tb('base_16')
+local polish_hl = require('layers.ui.colors').get().polish_hl or {}
+local merge_highlights = require('layers.ui.utils').merge_highlights
 
 -- Standard syntax highlighting
 
-return {
+local highlights = {
   Boolean = {
     fg = theme.base09,
   },
@@ -116,3 +118,5 @@ return {
     fg = theme.base0A,
   },
 }
+
+return merge_highlights(highlights, polish_hl.syntax)

--- a/lua/layers/ui/integrations/treesitter.lua
+++ b/lua/layers/ui/integrations/treesitter.lua
@@ -1,6 +1,8 @@
 local theme = require('base46').get_theme_tb('base_16')
+local polish_hl = require('layers.ui.colors').get().polish_hl or {}
+local merge_highlights = require('layers.ui.utils').merge_highlights
 
-return {
+local highlights = {
   -- `@annotation` is not one of the default capture group, should we keep it
   ['@annotation'] = {
     fg = theme.base0F,
@@ -196,3 +198,5 @@ return {
     link = 'Conditional',
   },
 }
+
+return merge_highlights(highlights, polish_hl.treesitter)

--- a/lua/layers/ui/themes/onedark.lua
+++ b/lua/layers/ui/themes/onedark.lua
@@ -55,6 +55,20 @@ M.base_16 = {
   base0F = '#be5046',
 }
 
+M.polish_hl = {
+  treesitter = {
+    ['@punctuation.bracket'] = { fg = M.base_16.base05 },
+    ['@punctuation.delimiter'] = { fg = M.base_16.base05 },
+    ['@punctuation.special'] = { fg = M.base_16.base05 },
+    ['@tag.delimiter'] = { fg = M.base_16.base05 },
+  },
+
+  syntax = {
+    Delimiter = { fg = M.base_16.base05 },
+    SpecialChar = { fg = M.base_16.base05 },
+  },
+}
+
 M.type = 'dark'
 
 M = require('base46').override_theme(M, 'onedark')

--- a/lua/layers/ui/utils.lua
+++ b/lua/layers/ui/utils.lua
@@ -1,5 +1,24 @@
 local M = {}
 
+function M.merge_highlights(base, overrides)
+  local merged = vim.deepcopy(base or {})
+
+  for group, override in pairs(overrides or {}) do
+    local current = merged[group]
+
+    if type(override) ~= 'table' then
+      merged[group] = override
+    elseif override.link ~= nil or (type(current) == 'table' and current.link ~= nil) then
+      -- `link` cannot be merged with other attrs: replace the whole group.
+      merged[group] = vim.deepcopy(override)
+    else
+      merged[group] = vim.tbl_extend('force', current or {}, override)
+    end
+  end
+
+  return merged
+end
+
 M.hide_statusline = function()
   local hidden = require('layers.ui.options').statusline_filetype_exclude
   local shown = require('layers.ui.options').statusline_filetype_include


### PR DESCRIPTION
## Summary
- add a dedicated highlight merge helper that replaces groups when `link` is involved
- use the helper for Treesitter and syntax highlight overrides instead of `vim.tbl_deep_extend`
- add onedark `polish_hl` overrides for punctuation and delimiters

## Testing
- `nvim --headless +'+lua require("layers.ui.integrations.treesitter")' +'+lua require("layers.ui.integrations.syntax")' +qall`
- `nvim --headless +'+lua local merge=require("layers.ui.utils").merge_highlights local a={X={link="Tag"},Y={fg="#111111",bold=true}} local b={X={fg="#222222"},Y={italic=true},Z={link="Type"}} local m=merge(a,b) assert(m.X.link==nil and m.X.fg=="#222222") assert(m.Y.fg=="#111111" and m.Y.bold==true and m.Y.italic==true) assert(m.Z.link=="Type")' +qall`
